### PR TITLE
Remove private netlify function from public resource

### DIFF
--- a/docs/data/view-counter.md
+++ b/docs/data/view-counter.md
@@ -18,18 +18,3 @@ Want to show how many visitors your site/GitHub profiles gets? Quickly fill in t
 Website :- [https://visitorbadge.io/](https://visitorbadge.io/)
 
 > [https://api.visitorbadge.io/api/visitors?path={Your Custom Path Name}](https://api.visitorbadge.io/api/visitors?path=path\&countColor=%23263759)
-
-
-
-
-
-
-
-
-
-## Other APIs
-
-> [https://www.stefanjudis.com/.netlify/functions/stats-counter/?path=](https://www.stefanjudis.com/.netlify/functions/stats-counter/?path=){Your Custom Path (Unique Identifier)}
-
-
-


### PR DESCRIPTION
Heyooo. I just discovered that my private netlify function is listed as a publicly available stats counter API. I'd appreciate it if it could be removed. :) 

Thanks!